### PR TITLE
CircleCI : use custom Docker Image with dependencies pre-installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,9 @@ jobs:
     # TODO: Create a small custom docker image with all the dependencies we need
     #       preinstalled to reduce installation time.
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Test
           command: |
@@ -41,10 +40,9 @@ jobs:
   # the second half of the jobs are in this test
   short-tests-1:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Test
           command: |
@@ -61,12 +59,11 @@ jobs:
   # tagged release.
   publish-github-release:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Publish
           command: |
@@ -86,12 +83,11 @@ jobs:
   # This step should only be run in a cron job
   regression-test:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
     steps:
       - checkout
-      - *install-dependencies
       # Restore the cached resources.
       - restore_cache:
           # We try our best to bust the cache when the data changes by hashing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,5 @@
 version: 2
 
-references:
-  # Install the dependencies required for tests.
-  # Add the step "- *install-dependencies" to the beginning of your job to run
-  # this command.
-  install-dependencies: &install-dependencies
-    run:
-      name: Install dependencies
-      # TODO: We can split these dependencies up by job to reduce installation
-      # time.
-      command: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get -y -qq update
-        sudo apt-get -y install \
-            gcc-multilib-powerpc-linux-gnu gcc-arm-linux-gnueabi \
-            libc6-dev-armel-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-            libc6-dev-ppc64-powerpc-cross zstd gzip coreutils \
-            libcurl4-openssl-dev
-
 jobs:
   # the first half of the jobs are in this test
   short-tests-0:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,22 @@ jobs:
       - run:
           name: Test
           command: |
+            NOW="date +%s"
+            START=`$NOW`
             cc -v; CFLAGS="-O0 -Werror" make all && make clean
+            echo "Command 1 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make c99build         ; make clean
+            echo "Command 2 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make c11build         ; make clean
+            echo "Command 3 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make aarch64build     ; make clean
+            echo "Command 4 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make -j regressiontest; make clean
+            echo "Command 5 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make shortest         ; make clean
+            echo "Command 6 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make cxxtest          ; make clean
+            echo "Command 7 took $((`$NOW` - START)) seconds" ; START=`date +%s`
   # the second half of the jobs are in this test
   short-tests-1:
     docker:
@@ -28,13 +37,22 @@ jobs:
       - run:
           name: Test
           command: |
+            NOW="date +%s"
+            START=`$NOW`
             make gnu90build; make clean
+            echo "Command 1 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make gnu99build; make clean
+            echo "Command 2 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make ppc64build; make clean
+            echo "Command 3 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make ppcbuild  ; make clean
+            echo "Command 4 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make armbuild  ; make clean
+            echo "Command 5 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make -C tests test-legacy test-longmatch test-symbols; make clean
+            echo "Command 6 took $((`$NOW` - START)) seconds" ; START=`date +%s`
             make -C lib libzstd-nomt; make clean
+            echo "Command 7 took $((`$NOW` - START)) seconds" ; START=`date +%s`
   # This step is only run on release tags.
   # It publishes the source tarball as artifacts and if the GITHUB_TOKEN
   # environment variable is set it will publish the source tarball to the

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/buildpack-deps:bionic
+
+RUN sudo dpkg --add-architecture i386
+RUN sudo apt-get -y -qq update
+RUN sudo apt-get -y install \
+    gcc-multilib-powerpc-linux-gnu gcc-arm-linux-gnueabi \
+    libc6-dev-armel-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+    libc6-dev-ppc64-powerpc-cross zstd gzip coreutils \
+    libcurl4-openssl-dev


### PR DESCRIPTION
Instead of installing dependencies for each test, use custom Docker Image which already has dependencies pre-installed.